### PR TITLE
Adding Dockerfile + Github Action

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: docker
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine Docker tags
+        id: tags
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "tags=${{ vars.DOCKERHUB_USERNAME }}/mdx2:latest" >> $GITHUB_OUTPUT
+          else
+            echo "tags=${{ vars.DOCKERHUB_USERNAME }}/mdx2:test" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          tags: ${{ steps.tags.outputs.tags }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,5 +34,5 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v6
         with:
-          push: true
+          push: ${{ github.ref == 'refs/heads/main' }}
           tags: ${{ steps.tags.outputs.tags }}

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Publications describing [ando-lab/mdx2](https://github.com/ando-lab/mdx2):
 
 ### Prerequisites
 
-For a conda-based installation, you'll need [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html) or equivalent.
+For a conda-based installation, you'll need [micromamba](https://mamba.readthedocs.io/en/latest/installation/micromamba-installation.html) or equivalent. The Docker-based installed requires you to install and login to [Docker](https://www.docker.com/get-started/).
 
 ### User install (conda environment)
 
@@ -71,3 +71,23 @@ pip install -e ".[dev]"
 ```
 
 The last line installs mdx2 in editable mode, with optional development tools including pytest and ruff
+
+### Developer Install (Docker container)
+
+Pull image from Docker Hub and run the container. Search the Docker container logs for the localhost address to access mdx2 within a Jupyter Lab notebook or terminal.
+  a. Exposes ports 8880-8890
+  b. Platform supported: linux/amd64
+```bash
+git clone https://github.com/diff-use/mdx2.git && \
+cd mdx2 && \
+docker pull diffuseproject/mdx2:1.0.0 && \
+docker run --platform linux/amd64 --name 'mdx2_container' -it --rm -e JUPYTER_PORT={CONTAINER_PORT} -p {HOST_PORT}:{CONTAINER_PORT} -v "$(pwd)":/ home/dev diffuseproject/mdx2:latest && \
+docker logs 'mdx2_container'
+```
+
+(Optional) Open a shell in the running container:
+```bash
+docker exec -it 'mdx2_container' /bin/bash && \
+eval "$(micromamba shell hook --shell bash)" && \
+micromamba activate 'mdx2-dev'
+```

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ docker logs 'mdx2_container'
 
 (Optional) Open a shell in the running container:
 ```bash
-docker exec -it 'mdx2_container' /bin/bash && \
-eval "$(micromamba shell hook --shell bash)" && \
+docker exec -it 'mdx2_container' /bin/bash
+eval "$(micromamba shell hook --shell bash)"
 micromamba activate 'mdx2-dev'
 ```

--- a/dockerfile
+++ b/dockerfile
@@ -20,7 +20,7 @@ COPY env.yaml .
 
 # Use micromamba to create the environment and install packages
 RUN /usr/local/bin/micromamba create -f env.yaml -n mdx2-dev && \
-    /usr/local/bin/micromamba install -y -n mdx2-dev nexpy jupyterlab dials xia2 wget tar -c conda-forge && \
+    /usr/local/bin/micromamba install -y -n mdx2-dev nexpy jupyterlab jupyterlab-h5web dials xia2 wget tar -c conda-forge && \
     /usr/local/bin/micromamba clean --all --yes
 
 COPY . .

--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.10-slim AS stage1
+
+FROM mambaorg/micromamba:1.5.5 AS stage2
+
+FROM debian:stable-slim AS final
+
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY --from=stage1 /usr/local /usr/local
+COPY --from=stage2 /bin/micromamba /usr/local/bin/micromamba
+
+ENV PATH="/usr/local/bin:/opt/conda/bin:$PATH"
+
+# Ensure /opt/conda exists for micromamba to use
+RUN mkdir -p /opt/conda
+
+WORKDIR /home/dev
+
+COPY env.yaml .
+
+# Use micromamba to create the environment and install packages
+RUN /usr/local/bin/micromamba create -f env.yaml -n mdx2-dev && \
+    /usr/local/bin/micromamba install -y -n mdx2-dev nexpy jupyterlab dials xia2 wget tar -c conda-forge && \
+    /usr/local/bin/micromamba clean --all --yes
+
+COPY . .
+
+# Install the local package in editable mode within the environment
+RUN /usr/local/bin/micromamba run -n mdx2-dev pip install -e .
+
+EXPOSE 8888
+

--- a/dockerfile
+++ b/dockerfile
@@ -1,17 +1,19 @@
+# diffuseproject/mdx2:1.0.0 (https://hub.docker.com/repository/docker/diffuseproject/mdx2/tags/1.0.0/sha256-abfcf7d2feacdf9a207a13c2bb908d62e6f461259f78e82d3bb8983267446291)
+
 FROM python:3.10-slim AS stage1
 
 FROM mambaorg/micromamba:1.5.5 AS stage2
 
 FROM debian:stable-slim AS final
 
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates git
 
 COPY --from=stage1 /usr/local /usr/local
 COPY --from=stage2 /bin/micromamba /usr/local/bin/micromamba
 
 ENV PATH="/usr/local/bin:/opt/conda/bin:$PATH"
+ENV JUPYTER_PORT=8888
 
-# Ensure /opt/conda exists for micromamba to use
 RUN mkdir -p /opt/conda
 
 WORKDIR /home/dev
@@ -25,8 +27,11 @@ RUN /usr/local/bin/micromamba create -f env.yaml -n mdx2-dev && \
 
 COPY . .
 
+# Install dials-extensions pinned to a specific commit (963fe9e458a505a8443c988d45fb8dcb4532768f) for CHESS beamline compatibility
 # Install the local package in editable mode within the environment
+RUN /usr/local/bin/micromamba run -n mdx2-dev pip install git+https://github.com/FlexXBeamline/dials-extensions.git@963fe9e458a505a8443c988d45fb8dcb4532768f
 RUN /usr/local/bin/micromamba run -n mdx2-dev pip install -e .
 
-EXPOSE 8888
+EXPOSE 8880-8890
 
+CMD /usr/local/bin/micromamba run -n mdx2-dev jupyter lab --ip=0.0.0.0 --port=$JUPYTER_PORT --no-browser --allow-root


### PR DESCRIPTION
Dockerfile Changes
-Expose ports 8880-8890
-Now users can set their own Jupyter port (the same as the container port [ports 8880-8890])
-Git cloned dials-extensions and pinned commit
-A Jupyter lab server is now launched at the creation of the docker container
*Dockerfile is now primarily used for CI through a GitHub action that rebuilds the image after each push to main